### PR TITLE
Fix building on case insensitive filesystems.

### DIFF
--- a/notebooks/color.clj
+++ b/notebooks/color.clj
@@ -448,17 +448,17 @@ c/colorspaces-list
 
 ;; ### Polar coordinates
 
-;; For every luma based color space you can create polar representation with `to-lch` or `from-lch`. Some of the colorspace are already predefined.
+;; For every luma based color space you can create polar representation with `to-luma-color-hue` or `from-luma-color-hue`. Some of the colorspace are already predefined.
 
 ;; The following two are the same:
 
-(c/to-lch c/to-LUV [20 30 100])
+(c/to-luma-color-hue c/to-LUV [20 30 100])
 (c/to-LCHuv [20 30 100])
 
 ;; Let's make LCH out of YUV.
 
-(def yuv-polar (c/to-lch c/to-YUV [20 30 100]))
-(c/from-lch c/from-YUV yuv-polar)
+(def yuv-polar (c/to-luma-color-hue c/to-YUV [20 30 100]))
+(c/from-luma-color-hue c/from-YUV yuv-polar)
 
 ;; You can create conversion pair by calling `make-LCH` function.
 

--- a/src/clojure2d/color.clj
+++ b/src/clojure2d/color.clj
@@ -900,7 +900,7 @@
 
 ;;
 
-(defn to-lch
+(defn to-luma-color-hue
   "For given color space return polar representation of the color"
   ^Vec4 [to c]
   (let [^Vec4 cc (to c)
@@ -909,7 +909,7 @@
         C (m/hypot-sqrt (.y cc) (.z cc))]
     (Vec4. (.x cc) C Hd (.w cc))))
 
-(defn from-lch
+(defn from-luma-color-hue
   "For given color space convert from polar representation of the color"
   ^Vec4 [from c]
   (let [^Vec4 c (pr/to-color c)
@@ -921,7 +921,7 @@
 (defn to-Oklch
   "RGB -> Oklch"
   ^Vec4 [c]
-  (to-lch to-Oklab c))
+  (to-luma-color-hue to-Oklab c))
 
 (defn to-Oklch*
   "RGB -> Oklch, normalized"
@@ -935,7 +935,7 @@
 (defn from-Oklch
   "Oklch -> RGB"
   ^Vec4 [c]
-  (from-lch from-Oklab c))
+  (from-luma-color-hue from-Oklab c))
 
 (defn from-Oklch*
   "Oklch -> RGB, normalized"
@@ -1768,7 +1768,7 @@
   * H: 0.0 - 360.0"
   {:metadoc/categories meta-conv}
   ^Vec4 [c]
-  (to-lch to-LAB c))
+  (to-luma-color-hue to-LAB c))
 
 (defn to-LCH*
   "RGB -> LCH, normalized"
@@ -1786,7 +1786,7 @@
   For ranges, see [[to-LCH]]."
   {:metadoc/categories meta-conv}
   ^Vec4 [c]
-  (from-lch from-LAB c))
+  (from-luma-color-hue from-LAB c))
 
 (defn from-LCH*
   "LCH -> RGB, normalized"
@@ -1810,7 +1810,7 @@
   * H: 0.0 - 360.0"
   {:metadoc/categories meta-conv}
   ^Vec4 [c]
-  (to-lch to-LUV c))
+  (to-luma-color-hue to-LUV c))
 
 (defn to-LCHuv*
   "RGB -> LCHuv, normalized"
@@ -1828,7 +1828,7 @@
   For ranges, see [[to-LCH]]."
   {:metadoc/categories meta-conv}
   ^Vec4 [c]
-  (from-lch from-LUV c))
+  (from-luma-color-hue from-LUV c))
 
 (defn from-LCHuv*
   "LCHuv -> RGB, normalized"
@@ -2262,7 +2262,7 @@
   * H: 0.0 - 360.0"
   {:metadoc/categories meta-conv}
   ^Vec4 [c]
-  (to-lch to-JAB c))
+  (to-luma-color-hue to-JAB c))
 
 (defn to-JCH*
   "RGB -> JCH, normalized"
@@ -2280,7 +2280,7 @@
   For ranges, see [[to-JCH]]."
   {:metadoc/categories meta-conv}
   ^Vec4 [c]
-  (from-lch from-JAB c))
+  (from-luma-color-hue from-JAB c))
 
 (defn from-JCH*
   "JCH -> RGB, normalized"
@@ -3508,8 +3508,8 @@
   "Create LCH conversion functions pair from any luma based color space. "
   [cs]
   (let [[to from] (colorspaces cs)]
-    [(partial to-lch to)
-     (partial from-lch from)]))
+    [(partial to-luma-color-hue to)
+     (partial from-luma-color-hue from)]))
 
 (defn complementary
   "Create complementary color. Possible colorspaces are:


### PR DESCRIPTION
Rename to/from-lch to avoid conflict with to/from-LCH on case insensitive filesystems.

I think I've caught all uses. The tests pass.

Fixes #21