### PR TITLE
Add clj-kondo config for with-canvas* macros

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,4 @@
+{:lint-as {clojure2d.core/with-canvas clojure.core/let
+           clojure2d.core/with-canvas-> clojure.core/->}
+ :hooks {:macroexpand {clojure2d.core/with-oriented-canvas clojure2d.core/with-oriented-canvas
+                       clojure2d.core/with-oriented-canvas-> clojure2d.core/with-oriented-canvas->}}}

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,1 @@
-{:lint-as {clojure2d.core/with-canvas clojure.core/let
-           clojure2d.core/with-canvas-> clojure.core/->}
- :hooks {:macroexpand {clojure2d.core/with-oriented-canvas clojure2d.core/with-oriented-canvas
-                       clojure2d.core/with-oriented-canvas-> clojure2d.core/with-oriented-canvas->}}}
+{:config-paths ["../resources/clj-kondo.exports/clojure2d/clojure2d"]}

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ _site
 /log
 utils/palettes/.nrepl-port
 utils/palettes/target
-.clj-kondo
+.clj-kondo/.cache
 .lsp
 /playground
 /.clerk

--- a/resources/clj-kondo.exports/clojure2d/clojure2d/config.edn
+++ b/resources/clj-kondo.exports/clojure2d/clojure2d/config.edn
@@ -1,0 +1,4 @@
+{:lint-as {clojure2d.core/with-canvas clojure.core/let
+           clojure2d.core/with-canvas-> clojure.core/->}
+ :hooks {:macroexpand {clojure2d.core/with-oriented-canvas clojure2d.core/with-oriented-canvas
+                       clojure2d.core/with-oriented-canvas-> clojure2d.core/with-oriented-canvas->}}}

--- a/resources/clj-kondo.exports/clojure2d/core.clj
+++ b/resources/clj-kondo.exports/clojure2d/core.clj
@@ -1,0 +1,11 @@
+(ns clojure2d.core)
+
+(defmacro with-oriented-canvas
+  [_orientation [c canv] & body]
+  `(clojure.core/let [~c ~canv]
+     ~@body))
+
+(defmacro with-oriented-canvas->
+  [_orientation canv & body]
+  `(clojure.core/-> ~canv
+     ~@body))

--- a/src/clojure2d/core.clj
+++ b/src/clojure2d/core.clj
@@ -593,8 +593,9 @@ Default hint for Canvas is `:high`. You can set also hint for Window which means
 (defmacro with-canvas
   "Macro which takes care to create and destroy `Graphics2D` object for drawings on canvas. Macro returns result of last call.
 
-  See also [[with-canvas->]]." 
-  {:metadoc/categories #{:canvas}}
+  See also [[with-canvas->]]."
+  {:metadoc/categories #{:canvas}
+   :clj-kondo/lint-as 'clojure.core/let}
   [[c canvas] & body]
   `(let [~c (make-graphics ~canvas)
          result# (do ~@body)]

--- a/src/clojure2d/core.clj
+++ b/src/clojure2d/core.clj
@@ -580,8 +580,7 @@ Default hint for Canvas is `:high`. You can set also hint for Window which means
   Each function have to accept canvas as second parameter and have to return canvas.
 
   See also [[with-canvas]]."
-  {:metadoc/categories #{:canvas}
-   :clj-kondo/lint-as 'clojure.core/->}
+  {:metadoc/categories #{:canvas}}
   [canvas & body]  
   `(let [newcanvas# (make-graphics ~canvas)
          result# (-> newcanvas#

--- a/src/clojure2d/core.clj
+++ b/src/clojure2d/core.clj
@@ -593,9 +593,8 @@ Default hint for Canvas is `:high`. You can set also hint for Window which means
 (defmacro with-canvas
   "Macro which takes care to create and destroy `Graphics2D` object for drawings on canvas. Macro returns result of last call.
 
-  See also [[with-canvas->]]."
-  {:metadoc/categories #{:canvas}
-   :clj-kondo/lint-as 'clojure.core/let}
+  See also [[with-canvas->]]." 
+  {:metadoc/categories #{:canvas}}
   [[c canvas] & body]
   `(let [~c (make-graphics ~canvas)
          result# (do ~@body)]

--- a/src/clojure2d/core.clj
+++ b/src/clojure2d/core.clj
@@ -580,7 +580,8 @@ Default hint for Canvas is `:high`. You can set also hint for Window which means
   Each function have to accept canvas as second parameter and have to return canvas.
 
   See also [[with-canvas]]."
-  {:metadoc/categories #{:canvas}}
+  {:metadoc/categories #{:canvas}
+   :clj-kondo/lint-as 'clojure.core/->}
   [canvas & body]  
   `(let [newcanvas# (make-graphics ~canvas)
          result# (-> newcanvas#


### PR DESCRIPTION
The latest version of clj-kondo allows attaching configuration directly onto a macro via its metadata ([link](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#inline-macro-configuration)).

This prevents getting lots of linter warnings like:
`clojure2d.core/flip-y is called with 0 args but expects 1  [clj-kondo(invalid-arity)]`